### PR TITLE
Update getAttributeDefaults.xsl

### DIFF
--- a/docs/odf1.3/content.odf13-default-values.xml
+++ b/docs/odf1.3/content.odf13-default-values.xml
@@ -599,12 +599,13 @@
       <attribute name="xlink:type"
                  defaultValue="simple"
                  element="text:section-source"/>
-      <attribute name="" defaultValue="false"/>
-      <attribute name="" defaultValue="linearpolynomialexponential"/>
-      <attribute name="" defaultValue="2"/>
-      <attribute name="" defaultValue=""/>
-      <attribute name="" defaultValue="false"/>
-      <attribute name="" defaultValue="true"/>
-      <attribute name="" defaultValue="foreground"/>
+      <attribute name="chart:regression-force-intercept" defaultValue="false"/>
+      <attribute name="chart:regression-intercept-value"
+                 defaultValue="linearpolynomialexponential"/>
+      <attribute name="chart:regression-max-degree" defaultValue="2"/>
+      <attribute name="chart:regression-name" defaultValue=""/>
+      <attribute name="style:contextual-spacing" defaultValue="false"/>
+      <attribute name="style:join-border" defaultValue="true"/>
+      <attribute name="style:run-through" defaultValue="foreground"/>
    </attributes>
 </config>

--- a/src/test/resources/odf1.3/tools/getAttributeDefaults.xsl
+++ b/src/test/resources/odf1.3/tools/getAttributeDefaults.xsl
@@ -61,7 +61,7 @@
         -->
         <xsl:variable name="referenceToken" select="text:reference-mark-start/@text:name[contains(.,'attribute-') or contains(.,'property-')]" />
         <xsl:choose>
-            <xsl:when test="contains($referenceToken, '_element') and contains($referenceToken,'attibute-')">
+            <xsl:when test="contains($referenceToken, '_element') and contains($referenceToken,'attribute-')">
                 <!-- the name of the attribute 
                 attribute-draw:may-script
                 attribute-draw:type_element-draw:connector

--- a/src/test/resources/odf1.3/tools/getAttributeDefaults.xsl
+++ b/src/test/resources/odf1.3/tools/getAttributeDefaults.xsl
@@ -59,9 +59,9 @@
         <!-- Within the header is a reference token, which gives clues about the default value's attribute for instance: 
             <text:reference-mark-start text:name="attribute-table:number-columns-repeated_element-table:table-cell"/>            
         -->
-        <xsl:variable name="referenceToken" select="text:reference-mark-start/@text:name[contains(.,'attribute-')]" />
+        <xsl:variable name="referenceToken" select="text:reference-mark-start/@text:name[contains(.,'attribute-') or contains(.,'property-')]" />
         <xsl:choose>
-            <xsl:when test="contains($referenceToken, '_element')">
+            <xsl:when test="contains($referenceToken, '_element') and contains($referenceToken,'attibute-')">
                 <!-- the name of the attribute 
                 attribute-draw:may-script
                 attribute-draw:type_element-draw:connector
@@ -70,9 +70,15 @@
                 -->
                 <xsl:value-of select="substring-after(substring-before($referenceToken, '_element'), 'attribute-')" />
             </xsl:when>
+        	<xsl:when test="contains($referenceToken, '_element')">
+        		<xsl:value-of select="substring-after(substring-before($referenceToken, '_element'), 'property-')" />
+        	</xsl:when>
+        	<xsl:when test="contains($referenceToken,'attribute-')">
+        		<!-- the name of the attribute -->
+        		<xsl:value-of select="substring-after($referenceToken, 'attribute-')" />
+        	</xsl:when>
             <xsl:otherwise>
-                <!-- the name of the attribute -->
-                <xsl:value-of select="substring-after($referenceToken, 'attribute-')" />
+            	<xsl:value-of select="substring-after($referenceToken, 'property-')" />
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>


### PR DESCRIPTION
Allow for 'property-' as a prefix in reference marks for attributes in Part 3 Chapter 20.