### PR TITLE
Commenting & refactoring XSL

### DIFF
--- a/docs/odf1.3/content.odf13-default-values.xml
+++ b/docs/odf1.3/content.odf13-default-values.xml
@@ -16,14 +16,11 @@
       <attribute name="db:append-table-alias-name" defaultValue="true"/>
       <attribute name="db:apply-command" defaultValue="false"/>
       <attribute name="db:boolean-comparison-mode" defaultValue="equal-integer"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="db:decimal" defaultValue="."/>
       <attribute name="db:delete-rule" defaultValue="no-action"/>
       <attribute name="db:enable-sql92-check" defaultValue="false"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="db:encoding" defaultValue="utf-8"/>
       <attribute name="db:escape-processing" defaultValue="true"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="db:field" defaultValue=";"/>
       <attribute name="db:ignore-driver-privileges" defaultValue="true"/>
       <attribute name="db:is-first-row-header-line" defaultValue="true"/>
@@ -31,10 +28,8 @@
       <attribute name="db:is-table-name-length-limited" defaultValue="true"/>
       <attribute name="db:parameter-name-substitution" defaultValue="true"/>
       <attribute name="db:show-deleted" defaultValue="false"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="db:string" defaultValue="."/>
       <attribute name="db:suppress-version-columns" defaultValue="true"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="db:thousand" defaultValue=","/>
       <attribute name="db:use-catalog" defaultValue="false"/>
       <attribute name="db:visible" defaultValue="true"/>
@@ -48,38 +43,24 @@
       <attribute name="draw:display" defaultValue="always"/>
       <attribute name="draw:extrusion" defaultValue="false"/>
       <attribute name="draw:extrusion-allowed" defaultValue="false"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="draw:extrusion-brightness" defaultValue="33%"/>
       <attribute name="draw:extrusion-color" defaultValue="false"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="draw:extrusion-depth" defaultValue="36pt 0"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="draw:extrusion-diffusion" defaultValue="0%"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="draw:extrusion-first-light-direction" defaultValue="(5 0 1)"/>
       <attribute name="draw:extrusion-first-light-harsh" defaultValue="true"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="draw:extrusion-first-light-level" defaultValue="66%"/>
       <attribute name="draw:extrusion-light-face" defaultValue="true"/>
       <attribute name="draw:extrusion-metal" defaultValue="false"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="draw:extrusion-number-of-line-segments" defaultValue="30"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="draw:extrusion-origin" defaultValue="0.5 -0.5"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="draw:extrusion-rotation-angle" defaultValue="0 0"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="draw:extrusion-second-light-direction" defaultValue="(-5 0 1)"/>
       <attribute name="draw:extrusion-second-light-harsh" defaultValue="true"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="draw:extrusion-second-light-level" defaultValue="66%"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="draw:extrusion-shininess" defaultValue="50%"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="draw:extrusion-skew" defaultValue="50 45"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="draw:extrusion-specularity" defaultValue="0%"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="draw:extrusion-viewpoint" defaultValue="3.5cm -3.5cm 25cm)"/>
       <attribute name="draw:glue-point-type" defaultValue="none"/>
       <attribute name="draw:handle-mirror-horizontal" defaultValue="false"/>
@@ -95,19 +76,14 @@
       <attribute name="draw:text-path-mode" defaultValue="normal"/>
       <attribute name="draw:text-path-same-letter-heights" defaultValue="false"/>
       <attribute name="draw:text-path-scale" defaultValue="path"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="draw:text-rotate-angle" defaultValue="0"/>
       <attribute name="draw:type" defaultValue="standard" element="draw:connector"/>
       <attribute name="draw:type"
                  defaultValue="non-primitive"
                  element="draw:enhanced-geometry"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="fo:end-indent" defaultValue="0cm"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="fo:space-after" defaultValue="0cm"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="fo:space-before" defaultValue="0cm"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="fo:start-indent" defaultValue="0cm"/>
       <attribute name="form:allow-deletes" defaultValue="true"/>
       <attribute name="form:allow-inserts" defaultValue="true"/>
@@ -119,13 +95,10 @@
       <attribute name="form:convert-empty-to-null" defaultValue="false"/>
       <attribute name="form:current-selected" defaultValue="false"/>
       <attribute name="form:default-button" defaultValue="false"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="form:delay-for-repeat" defaultValue="PT0.050S"/>
       <attribute name="form:disabled" defaultValue="false"/>
       <attribute name="form:dropdown" defaultValue="false"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="form:echo-char" defaultValue="* (U+002A, ASTERISK)"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="form:enctype" defaultValue="application/x-www-form-urlencoded"/>
       <attribute name="form:escape-processing" defaultValue="true"/>
       <attribute name="form:ignore-result" defaultValue="false"/>
@@ -140,13 +113,11 @@
       <attribute name="form:selected" defaultValue="false"/>
       <attribute name="form:spin-button" defaultValue="false"/>
       <attribute name="form:state" defaultValue="unchecked"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="form:step-size" defaultValue="1"/>
       <attribute name="form:tab-stop" defaultValue="true"/>
       <attribute name="form:toggle" defaultValue="false"/>
       <attribute name="form:validation" defaultValue="false"/>
       <attribute name="number:automatic-order" defaultValue="false"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="number:decimal-places"
                  defaultValue="0"
                  element="number:seconds"/>
@@ -155,7 +126,6 @@
       <attribute name="number:forced-exponent-sign" defaultValue="true"/>
       <attribute name="number:grouping" defaultValue="false"/>
       <attribute name="number:textual" defaultValue="false"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="number:transliteration-format" defaultValue="1"/>
       <attribute name="number:transliteration-style" defaultValue="short"/>
       <attribute name="number:truncate-on-overflow" defaultValue="true"/>
@@ -177,7 +147,6 @@
       <attribute name="presentation:show-end-of-presentation-slide" defaultValue="true"/>
       <attribute name="presentation:show-logo" defaultValue="false"/>
       <attribute name="presentation:speed" defaultValue="medium"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="presentation:start-scale" defaultValue="100%"/>
       <attribute name="presentation:start-with-navigator" defaultValue="false"/>
       <attribute name="presentation:stay-on-top" defaultValue="false"/>
@@ -191,31 +160,23 @@
       <attribute name="smil:calcMode"
                  defaultValue="paced"
                  element="anim:animateMotion"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="smil:decelerate" defaultValue="0."/>
       <attribute name="smil:direction"
                  defaultValue="forward"
                  element="anim:transitionFilter"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="smil:fadeColor" defaultValue="#000000"/>
       <attribute name="smil:mode" defaultValue="in"/>
       <attribute name="smil:restart" defaultValue="default"/>
       <attribute name="smil:restartDefault" defaultValue="inherit"/>
       <attribute name="style:adjustment" defaultValue="left"/>
       <attribute name="style:auto-update" defaultValue="false"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="style:color"
                  defaultValue="#000000"
                  element="style:column-sep"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="style:distance" defaultValue="0cm"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="style:height" defaultValue="100%"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="style:leader-text" defaultValue=" "/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="style:length" defaultValue="1"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="style:lines" defaultValue="1"/>
       <attribute name="style:page-usage" defaultValue="all"/>
       <attribute name="style:position"
@@ -229,21 +190,14 @@
       <attribute name="style:vertical-align"
                  defaultValue="top"
                  element="style:column-sep"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="svg:cx" defaultValue="50%" element="svg:radialGradient"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="svg:cy" defaultValue="50%" element="svg:radialGradient"/>
       <attribute name="svg:gradientUnits" defaultValue="objectBoundingBox"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="svg:r" defaultValue="50%" element="svg:radialGradient"/>
       <attribute name="svg:spreadMethod" defaultValue="pad"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="svg:x1" defaultValue="0%" element="svg:linearGradient"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="svg:x2" defaultValue="100%" element="svg:linearGradient"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="svg:y1" defaultValue="0%" element="svg:linearGradient"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="svg:y2" defaultValue="100%" element="svg:linearGradient"/>
       <attribute name="table:acceptance-state" defaultValue="pending"/>
       <attribute name="table:allow-empty-cell" defaultValue="true"/>
@@ -267,7 +221,6 @@
       <attribute name="table:copy-back" defaultValue="true"/>
       <attribute name="table:copy-formulas" defaultValue="true"/>
       <attribute name="table:copy-styles" defaultValue="true"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="table:count" defaultValue="1"/>
       <attribute name="table:data-type"
                  defaultValue="text"
@@ -278,7 +231,6 @@
       <attribute name="table:data-type"
                  defaultValue="automatic"
                  element="table:sort-groups"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="table:date-value" defaultValue="1899-12-30"/>
       <attribute name="table:display"
                  defaultValue="true"
@@ -311,29 +263,21 @@
       <attribute name="table:is-sub-table" defaultValue="false"/>
       <attribute name="table:link-to-source-data" defaultValue="false"/>
       <attribute name="table:matrix-covered" defaultValue="false"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="table:maximum-difference" defaultValue="0.001"/>
       <attribute name="table:message-type" defaultValue="stop"/>
       <attribute name="table:mode" defaultValue="copy-all"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="table:null-year" defaultValue="1930"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="table:number-columns-repeated"
                  defaultValue="1"
                  element="table:covered-table-cell"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="table:number-columns-repeated"
                  defaultValue="1"
                  element="table:table-cell"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="table:number-columns-repeated"
                  defaultValue="1"
                  element="table:table-column"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="table:number-columns-spanned" defaultValue="1"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="table:number-rows-repeated" defaultValue="1"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="table:number-rows-spanned" defaultValue="1"/>
       <attribute name="table:on-update-keep-size" defaultValue="true"/>
       <attribute name="table:on-update-keep-styles" defaultValue="false"/>
@@ -356,7 +300,6 @@
       <attribute name="table:protected"
                  defaultValue="false"
                  element="table:table-cell"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="table:protection-key-digest-algorithm"
                  defaultValue="http://www.w3.org/2000/09/xmldsig#sha1"/>
       <attribute name="table:range-usable-as" defaultValue="none"/>
@@ -364,7 +307,6 @@
                  defaultValue="true"/>
       <attribute name="table:show-filter-button" defaultValue="true"/>
       <attribute name="table:status" defaultValue="disable"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="table:steps" defaultValue="100"/>
       <attribute name="table:structure-protected" defaultValue="false"/>
       <attribute name="table:use-banding-columns-styles" defaultValue="false"/>
@@ -376,7 +318,6 @@
       <attribute name="table:use-labels" defaultValue="none"/>
       <attribute name="table:use-regular-expressions" defaultValue="true"/>
       <attribute name="table:use-wildcards" defaultValue="false"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="table:used-hierarchy" defaultValue="-1-1"/>
       <attribute name="table:value-type" defaultValue="date"/>
       <attribute name="table:visibility" defaultValue="visible"/>
@@ -394,7 +335,6 @@
       <attribute name="text:display"
                  defaultValue="number"
                  element="text:index-entry-chapter"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="text:display-levels" defaultValue="1"/>
       <attribute name="text:global" defaultValue="false"/>
       <attribute name="text:index-scope" defaultValue="document"/>
@@ -415,7 +355,6 @@
                  element="text:user-index-source"/>
       <attribute name="text:ignore-case" defaultValue="false"/>
       <attribute name="text:is-list-header" defaultValue="false"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="text:level"
                  defaultValue="1"
                  element="text:numbered-paragraph"/>
@@ -430,15 +369,12 @@
       <attribute name="text:restart-on-page" defaultValue="false"/>
       <attribute name="text:sort-ascending" defaultValue="true"/>
       <attribute name="text:sort-by-position" defaultValue="true"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="text:start-value"
                  defaultValue="1"
                  element="text:list-level-style-number"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="text:start-value"
                  defaultValue="1"
                  element="text:notes-configuration"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="text:start-value"
                  defaultValue="1"
                  element="text:outline-level-style"/>
@@ -514,7 +450,6 @@
       <attribute name="xlink:actuate"
                  defaultValue="onLoad"
                  element="text:list-level-style-image"/>
-      <!--The following attribute default value is listed in the ODF schema-->
       <attribute name="xlink:href" defaultValue=".." element="chart:chart"/>
       <attribute name="xlink:href" defaultValue="" element="draw:applet"/>
       <attribute name="xlink:show" defaultValue="replace" element="meta:auto-reload"/>

--- a/src/test/resources/odf1.3/tools/getAttributeDefaults.xsl
+++ b/src/test/resources/odf1.3/tools/getAttributeDefaults.xsl
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2020 Svante Schubert
-  Copyright 2000, 2010 Oracle and/or its affiliates.
-  Copyright 2009 IBM. All rights reserved.
-
   Use is subject to license terms.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -20,14 +16,14 @@
 
 -->
 <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xt="http://www.jclark.com/xt" xmlns:common="http://exslt.org/common" xmlns:xalan="http://xml.apache.org/xalan" exclude-result-prefixes="chart config dc dom dr3d draw fo form math meta number office ooo oooc ooow script style svg table text xforms xlink xsd xsi xt common xalan" xmlns="http://www.w3.org/1999/xhtml">
-    <!-- Extracting default values from the ODF 1.2 part1 specification
-		Version 1.2.1 by Svante.Schubert@ gmail.com  -->
+    <!-- Extracting default values from the ODF schema specification
+        Idea by Daniel Carrera - https://danielcarrera.space/
+		Since ODF 1.2 maintained by Svante Schubert -->
     <xsl:output method="xml" encoding="UTF-8" indent="yes" omit-xml-declaration="no" />
-
-    <xsl:mode streamable="yes" />
+    <xsl:param name="debug" select="false()" /> <!-- HERE! ENABLE DEBUG OUTPUT! -->
 
     <!-- ********************************************************** -->
-    <!-- *** Get the default attribute values for ODF elements  *** -->
+    <!-- *** Get the default attribute values for ODF attributes ** -->
     <!-- ********************************************************** -->
     <xsl:template match="/">
         <config xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rpt="http://openoffice.org/2005/report" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:rdfa="http://docs.oasis-open.org/opendocument/meta/rdfa#" office:version="1.2">
@@ -37,92 +33,110 @@
         </config>
     </xsl:template>
 
-    <!-- for every stylable text element with the indicator of a default value (ie. the style 'Default_20_Value')...  -->
-    <xsl:template match="*[@text:style-name='Default_20_Value']">
+    <!-- match every paragraph within the ODF specification declaring a default value (ie. has a 'Default_20_Value' style)  -->
+    <xsl:template match="text:p[@text:style-name='Default_20_Value']">
         <xsl:call-template name="get-default-value-declaration">
             <xsl:with-param name="attributeName">
-                <!-- the attribute name is being gathered, by traversing backwards in the document to the previous attribute declaration (found in a heading) -->
+                <!-- get the attribute name of the default value by traversing backwards in the document to the previous attribute declaration (found in a heading) -->
                 <xsl:apply-templates select="preceding::text:h[1]" mode="get-attribute-name" />
             </xsl:with-param>
         </xsl:call-template>
-
     </xsl:template>
 
 
-    <!-- starting from an attribute description where defaults exist..  -->
+    <!-- find the attribute name of the defaults value  -->
     <xsl:template match="text:h" mode="get-attribute-name">
-<!--        
-            <xsl:message>TextHeader:'<xsl:copy-of select="."/>'
-            
-            </xsl:message>
--->
-        <!-- Within the header is a reference token, which gives clues about the default value's attribute for instance: 
-            <text:reference-mark-start text:name="attribute-table:number-columns-repeated_element-table:table-cell"/>            
-        -->
-        <xsl:variable name="referenceToken" select="text:reference-mark-start/@text:name[contains(.,'attribute-') or contains(.,'property-')]" />
-        <xsl:choose>
-            <xsl:when test="contains($referenceToken, '_element') and contains($referenceToken,'attribute-')">
-                <!-- the name of the attribute 
-                attribute-draw:may-script
-                attribute-draw:type_element-draw:connector
-                attribute-draw:type_element-draw:enhanced-geometry
 
-                -->
-                <xsl:value-of select="substring-after(substring-before($referenceToken, '_element'), 'attribute-')" />
+        <xsl:if test="$debug=true()">
+            <xsl:message></xsl:message>            
+            <xsl:message></xsl:message>
+            <xsl:message></xsl:message>
+            <xsl:message>Preceding Header containing the ODF attribute name:</xsl:message>
+            <xsl:message><xsl:copy-of select="."/></xsl:message>
+        </xsl:if>
+
+        <!-- Within the header is a reference mark, which gives clues about the default value's attribute for instance:
+            <text:reference-mark-start text:name="attribute-table:number-columns-repeated_element-table:table-cell"/>
+                possible names of the reference-mark:
+                    attribute-draw:may-script
+                    attribute-draw:type_element-draw:connector
+                    attribute-draw:type_element-draw:enhanced-geometry
+                    property-style:run-through
+        -->
+        <xsl:variable name="referenceMark" select="text:reference-mark-start/@text:name[contains(.,'attribute-') or contains(.,'property-')]" />
+        <xsl:choose>
+            <xsl:when test="contains($referenceMark, '_element') and contains($referenceMark,'attribute-')">
+                <!-- example names of matched reference-mark:
+                        attribute-draw:may-script
+                        attribute-draw:type_element-draw:connector
+                        attribute-draw:type_element-draw:enhanced-geometry
+                        property-style:run-through
+                  -->
+                <xsl:value-of select="substring-after(substring-before($referenceMark, '_element'), 'attribute-')" />
             </xsl:when>
-        	<xsl:when test="contains($referenceToken, '_element')">
-        		<xsl:value-of select="substring-after(substring-before($referenceToken, '_element'), 'property-')" />
-        	</xsl:when>
-        	<xsl:when test="contains($referenceToken,'attribute-')">
-        		<!-- the name of the attribute -->
-        		<xsl:value-of select="substring-after($referenceToken, 'attribute-')" />
+        	<xsl:when test="contains($referenceMark,'attribute-')">
+                <!-- example names of matched reference-mark:
+                        attribute-draw:may-script
+                  -->
+        		<xsl:value-of select="substring-after($referenceMark, 'attribute-')" />
         	</xsl:when>
             <xsl:otherwise>
-            	<xsl:value-of select="substring-after($referenceToken, 'property-')" />
+            	<xsl:value-of select="substring-after($referenceMark, 'property-')" />
+                <!-- example name of matched reference-mark:
+                        property-style:run-through
+                  -->
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
 
-    <!-- Context is the preceding heading of a "Default_20_Value" styled text container (paragraph or span)-->
+    <!-- Context is the paragraph with "Default_20_Value" styled -->
     <xsl:template name="get-default-value-declaration">
-        <xsl:param name="attributeName" />
+        <xsl:param name="attributeName" /><!-- extraced from text reference from preceding header -->
 
-<!--
-        <xsl:message>TextContainer:'<xsl:copy-of select="."/>'
-        
-        </xsl:message>
--->
+        <xsl:if test="$debug=true()">
+            <xsl:message>.</xsl:message>
+            <xsl:message>From header extracted ODF attribute:</xsl:message> 
+            <xsl:message>@<xsl:value-of select="$attributeName"/></xsl:message>
+            <xsl:message>.</xsl:message>
+            <xsl:message>The paragraph with default value within:</xsl:message>
+            <xsl:message><xsl:copy-of select="."/></xsl:message>
+        </xsl:if>
 
         <xsl:variable name="defaultValue">
-            <!-- get the default Value (ie. the styleable text element with the style 'Attribute_20_Value')  -->
-            <xsl:variable name="defaultValueElement" select="string-join(*[@text:style-name='Attribute_20_Value' or @text:style-name='Attribute_20_Value_20_Instance'])" />
+            <!-- get the default Value (ie. the sum of all spans with 'Attribute_20_Value' style)  -->
+            <xsl:variable name="defaultValueString" select="string-join(text:span[@text:style-name='Attribute_20_Value' or @text:style-name='Attribute_20_Value_20_Instance'])" />
             <xsl:choose>
-                <xsl:when test="normalize-space($defaultValueElement) != ''">
-                    <xsl:value-of select="normalize-space($defaultValueElement)" />
+                <xsl:when test="normalize-space($defaultValueString) != ''">
+                    <xsl:value-of select="normalize-space($defaultValueString)" />
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:value-of select="$defaultValueElement" />
+                    <xsl:value-of select="$defaultValueString" />
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
+        <!-- With ODF 1.2 this no longer occurs as all default values were removed from the schema, 
+            due to the problem default value insertion into the XML by parsers
+            see https://github.com/oasis-tcs/odf-tc/blob/master/src/test/resources/odf1.3/tools/How_to_prepare_ODF_specification_documents.md
+             -->                
         <xsl:if test="*[@text:style-name='Attribute_20_Value_20_Instance']">
-            <xsl:comment>The following attribute default value is listed in the ODF schema</xsl:comment>
-            <xsl:text></xsl:text>
+            <xsl:if test="$debug=true()">
+                <xsl:message>WARNING:</xsl:message>
+                <xsl:message>   Style 'Attribute_20_Value_20_Instance' should be deprecated in favor to 'Attribute_20_Value'.</xsl:message>
+                <xsl:message>   The attribute '<xsl:value-of select="$attributeName"/>' does not have a default value in the ODF schema since ODF 1.2.</xsl:message>
+                <xsl:message>   Default avlues were removed due to the problem of (re)insertion during loading by XML by parsers!</xsl:message>
+            </xsl:if>    
         </xsl:if>
         <xsl:choose>
-            <xsl:when test="*[@text:style-name='Element']">
-
-<!--      
-        <xsl:message>ELEMENT CHILD:'<xsl:copy-of select="."/>'
-        </xsl:message>
--->
+            <xsl:when test="text:span[@text:style-name='Element']">
 
                 <!-- sometimes a default values only occurs on a certain element or elements -->
-                <xsl:for-each select="*[@text:style-name='Element']">
-<!--                  
-        <xsl:message>ELEMENT NEW CHILD:'<xsl:copy-of select="."/>'
-        </xsl:message>
--->
+                <xsl:for-each select="text:span[@text:style-name='Element']">
+
+                    <xsl:if test="$debug=true()">
+                        <xsl:message>.</xsl:message>
+                        <xsl:message>Span with 'Element' style:</xsl:message>
+                        <xsl:message><xsl:copy-of select="."/></xsl:message>
+                    </xsl:if>
 
                     <!-- use the element name without the brackets -->
                     <xsl:variable name="elementName">
@@ -131,6 +145,11 @@
                         </xsl:call-template>
                     </xsl:variable>
                     <xsl:if test="$elementName != ''">
+                        <xsl:if test="$debug=true()">
+                            <xsl:message>.</xsl:message>
+                            <xsl:message>Default applies only for ODF element:</xsl:message>
+                            <xsl:message>* <xsl:value-of select="$elementName" /></xsl:message>
+                        </xsl:if>
                         <xsl:element name="attribute">
                             <xsl:attribute name="name">
                                 <xsl:value-of select="$attributeName" />
@@ -159,12 +178,15 @@
         </xsl:choose>
     </xsl:template>
 
+    <!-- recursivly the element name is being gathered (span by span), as sometimes the element name was split by multiple spans 
+        these span contents are being concatenated until both element delimeter ('<' and '>') are found within the string -->
     <xsl:template name="get-element-name">
         <xsl:param name="nameString" />
-<!--
-        <xsl:message>NAMESTRING: *<xsl:copy-of select="$nameString"/>*        
-        </xsl:message>
--->
+
+        <xsl:if test="$debug=true()">
+            <xsl:message>Evaluating parent element name: '<xsl:copy-of select="$nameString"/>'</xsl:message>
+        </xsl:if>
+
         <xsl:choose>
             <xsl:when test="contains($nameString, '&lt;') and contains($nameString, '&gt;')">
                 <!-- the name of the element -->

--- a/src/test/resources/odf1.3/tools/getAttributeDefaults.xsl
+++ b/src/test/resources/odf1.3/tools/getAttributeDefaults.xsl
@@ -37,7 +37,7 @@
     <xsl:template match="text:p[@text:style-name='Default_20_Value']">
         <xsl:call-template name="get-default-value-declaration">
             <xsl:with-param name="attributeName">
-                <!-- get the attribute name of the default value by traversing backwards in the document to the previous attribute declaration (found in a heading) -->
+                <!-- get the attribute name of the default value by traversing backwards in the document to the previous attribute name (found in a heading) -->
                 <xsl:apply-templates select="preceding::text:h[1]" mode="get-attribute-name" />
             </xsl:with-param>
         </xsl:call-template>
@@ -48,7 +48,7 @@
     <xsl:template match="text:h" mode="get-attribute-name">
 
         <xsl:if test="$debug=true()">
-            <xsl:message></xsl:message>            
+            <xsl:message></xsl:message>
             <xsl:message></xsl:message>
             <xsl:message></xsl:message>
             <xsl:message>Preceding Header containing the ODF attribute name:</xsl:message>
@@ -95,7 +95,7 @@
 
         <xsl:if test="$debug=true()">
             <xsl:message>.</xsl:message>
-            <xsl:message>From header extracted ODF attribute:</xsl:message> 
+            <xsl:message>From header extracted ODF attribute:</xsl:message>
             <xsl:message>@<xsl:value-of select="$attributeName"/></xsl:message>
             <xsl:message>.</xsl:message>
             <xsl:message>The paragraph with default value within:</xsl:message>
@@ -114,17 +114,17 @@
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
-        <!-- With ODF 1.2 this no longer occurs as all default values were removed from the schema, 
+        <!-- With ODF 1.2 this no longer occurs as all default values were removed from the schema,
             due to the problem default value insertion into the XML by parsers
             see https://github.com/oasis-tcs/odf-tc/blob/master/src/test/resources/odf1.3/tools/How_to_prepare_ODF_specification_documents.md
-             -->                
+             -->
         <xsl:if test="*[@text:style-name='Attribute_20_Value_20_Instance']">
             <xsl:if test="$debug=true()">
                 <xsl:message>WARNING:</xsl:message>
                 <xsl:message>   Style 'Attribute_20_Value_20_Instance' should be deprecated in favor to 'Attribute_20_Value'.</xsl:message>
                 <xsl:message>   The attribute '<xsl:value-of select="$attributeName"/>' does not have a default value in the ODF schema since ODF 1.2.</xsl:message>
                 <xsl:message>   Default avlues were removed due to the problem of (re)insertion during loading by XML by parsers!</xsl:message>
-            </xsl:if>    
+            </xsl:if>
         </xsl:if>
         <xsl:choose>
             <xsl:when test="text:span[@text:style-name='Element']">
@@ -178,7 +178,7 @@
         </xsl:choose>
     </xsl:template>
 
-    <!-- recursivly the element name is being gathered (span by span), as sometimes the element name was split by multiple spans 
+    <!-- recursivly the element name is being gathered (span by span), as sometimes the element name was split by multiple spans
         these span contents are being concatenated until both element delimeter ('<' and '>') are found within the string -->
     <xsl:template name="get-element-name">
         <xsl:param name="nameString" />


### PR DESCRIPTION
Before adding the conditional default styles, I had to investigate the existing feature of the XSL and did a slight refactoring and major commenting task.

With this patch, only the misleading comments had been removed and debug output messages were improved.
In addition, now there is a debug variable to enable all messages with one small change.