### PR TITLE
temporarily revert to known working XHTML export

### DIFF
--- a/src/test/resources/odf1.4/tools/odf2html/export/common/body.xsl
+++ b/src/test/resources/odf1.4/tools/odf2html/export/common/body.xsl
@@ -81,7 +81,7 @@
     <!-- *************** -->
 
     <!-- ID / NAME of text-box -->
-    <xsl:template match="@draw:name | @text:id | @xml:id">
+    <xsl:template match="@draw:name">
         <xsl:attribute name="id">
             <xsl:choose>
                 <xsl:when test="number(substring(.,1,1))">

--- a/src/test/resources/odf1.4/tools/odf2html/export/common/styles/style_collector.xsl
+++ b/src/test/resources/odf1.4/tools/odf2html/export/common/styles/style_collector.xsl
@@ -504,8 +504,6 @@
     </xsl:template>
 
 
-    <!-- Context is <style:style> with all style properties elements containing attributes, accessed by */@prop 
-        overwriting the ODF style properties that are being inherited from the 'inheritedStyleProperties' parameter! -->
     <xsl:template name="create-inherited-style-properties">
         <xsl:param name="inheritedStyleProperties" />
 
@@ -513,58 +511,8 @@
            <!-- Writing all inherited style properties -->
             <xsl:for-each select="$inheritedStyleProperties/@*">
                 <xsl:sort select="name()" />
-
-                <!-- Normalization three ODF attributes to one ODF attribute fo:background color (only temporary not ODF conform but eases mapping to ODF)
-                There are two different background color: 
-                    1) fo:background-color
-                    2) draw:fill-color
-                    mapped to one in CSS.
-                    In addition if there is the attribute @draw:fill="none" the background is 'transparent' -->
-                <xsl:choose>
-                    <xsl:when test="name() = 'draw:fill-color' or name() = 'fo:background-color' or name() = 'draw:fill'">
-                        <xsl:choose>
-                            <xsl:when test="$inheritedStyleProperties/@draw:fill='none'">
-                                <xsl:attribute name="fo:background-color">transparent</xsl:attribute>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <xsl:choose>
-                                    <xsl:when test="name()!='draw:fill'">
-                                        <xsl:attribute name="fo:background-color"><xsl:value-of select="."/></xsl:attribute>
-                                    </xsl:when>
-                                    <xsl:otherwise>
-                                        <xsl:attribute name="fo:background-color">transparent</xsl:attribute>
-                                    </xsl:otherwise>
-                                </xsl:choose>
-                            </xsl:otherwise>
-                        </xsl:choose>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:copy-of select="." />
-                    </xsl:otherwise>
-                </xsl:choose>
+                <xsl:copy-of select="." />
             </xsl:for-each>
-
-            <xsl:if test="*/@draw:fill-color or */@fo:background-color or */@draw:fill">                
-                <xsl:choose>
-                    <xsl:when test="*/@draw:fill='none'">
-                        <xsl:attribute name="fo:background-color">transparent</xsl:attribute>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:choose>
-                            <xsl:when test="*/@draw:fill-color">
-                                <xsl:attribute name="fo:background-color"><xsl:value-of select="*/@draw:fill-color"/></xsl:attribute>
-                            </xsl:when>
-                            <xsl:when test="*/@fo:background-color">
-                                <xsl:attribute name="fo:background-color"><xsl:value-of select="*/@fo:background-color"/></xsl:attribute>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <xsl:attribute name="fo:background-color">transparent</xsl:attribute>
-                            </xsl:otherwise>
-                        </xsl:choose>
-                    </xsl:otherwise>
-                </xsl:choose>
-            </xsl:if>
-
 
             <!-- split border into border parts for better activation-check on style:joint-border feature -->
             <xsl:if test="*/@fo:border">
@@ -576,7 +524,7 @@
 
            <!--All current attributes will override already inserted attributes of the same name
                XSLT Spec: "Adding an attribute to an element replaces any existing attribute of that element with the same expanded-name." -->
-            <xsl:for-each select="*/@*[name() != 'style:font-size-rel'][name() != 'fo:border'][name() != 'draw:fill-color']">
+            <xsl:for-each select="*/@*[name() != 'style:font-size-rel'][name() != 'fo:border']">
                 <xsl:copy-of select="." />
             </xsl:for-each>
 
@@ -620,20 +568,21 @@
     <xsl:template name="write-collected-styles">
         <xsl:param name="globalData" />
 
-        <xsl:message>all-doc-styles:start</xsl:message>
+        <xsl:message>&lt;all-doc-styles&gt;</xsl:message>
         <xsl:for-each select="$globalData/all-doc-styles/style">
-            <xsl:message>***style:start</xsl:message>
-            <xsl:message>style:family="<xsl:value-of select="current()/@style:family" />"</xsl:message>
-            <xsl:message>style:name="<xsl:value-of select="current()/@style:name" />"</xsl:message>
-            <xsl:message>   with properties:</xsl:message>
+            <xsl:message>&lt;style</xsl:message>
+            <xsl:message>style:family="<xsl:value-of select="current()/@style:family" />"&gt;</xsl:message>
+            <xsl:message>style:name="<xsl:value-of select="current()/@style:name" />" </xsl:message>
+            <xsl:message>   &lt;*</xsl:message>
             <xsl:for-each select="*/@*">
                 <xsl:message>
                     <xsl:text></xsl:text>
                     <xsl:value-of select="name()" />="<xsl:value-of select="." />"</xsl:message>
             </xsl:for-each>
-            <xsl:message>***style:end</xsl:message>
+            <xsl:message>/&gt;</xsl:message>
+            <xsl:message>&lt;/style&gt;</xsl:message>
         </xsl:for-each>
-        <xsl:message>all-doc-styles:end</xsl:message>
+        <xsl:message>&lt;/all-doc-styles&gt;</xsl:message>
     </xsl:template>
 
     <xsl:template name="map-odf-style-properties">

--- a/src/test/resources/odf1.4/tools/odf2html/export/common/styles/style_mapping_css.xsl
+++ b/src/test/resources/odf1.4/tools/odf2html/export/common/styles/style_mapping_css.xsl
@@ -22,18 +22,11 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" exclude-result-prefixes="chart config dc dom dr3d draw fo form math meta number office ooo oooc ooow script style svg table text xforms xlink xsd xsi">
 
 
-    <!-- *** Background color handling *** -->
-    <xsl:template match="@fo:background-color | @draw:fill-color | @draw:fill">
-        <xsl:choose>
-            <xsl:when test="@draw:fill='none'">
-                <xsl:text>background-color:transparent; </xsl:text>
-            </xsl:when>
-            <xsl:when test="name()!='draw:fill'">
-                <xsl:text>background-color:</xsl:text>
-                <xsl:value-of select="."/>
-                <xsl:text>; </xsl:text>
-            </xsl:when>
-        </xsl:choose>
+    <!-- *** Properties with a 'fo:' prefix *** -->
+    <xsl:template match="@fo:background-color">
+        <xsl:text>background-color:</xsl:text>
+        <xsl:value-of select="."/>
+        <xsl:text>; </xsl:text>
     </xsl:template>
 
     <xsl:template match="@fo:border | @fo:border-top | @fo:border-bottom | @fo:border-left | @fo:border-right">

--- a/src/test/resources/odf1.4/tools/odf2html/export/common/table/table_rows.xsl
+++ b/src/test/resources/odf1.4/tools/odf2html/export/common/table/table_rows.xsl
@@ -196,10 +196,7 @@
         <xsl:param name="node-position" />
 
         <xsl:attribute name="class">
-            <xsl:call-template name="create-unique-style-id">
-                <xsl:with-param name="styleName" select="@table:style-name"/>
-                <xsl:with-param name="styleFamily" select="'table-row'"/>
-            </xsl:call-template>
+            <xsl:value-of select="translate(@table:style-name, '. %()/\+', '')" />
         </xsl:attribute>
     </xsl:template>
 

--- a/src/test/resources/odf1.4/tools/odf2html/export/common/table_of_content.xsl
+++ b/src/test/resources/odf1.4/tools/odf2html/export/common/table_of_content.xsl
@@ -93,10 +93,7 @@
                     </xsl:attribute>
                 </xsl:if>
                 <xsl:attribute name="class">
-                    <xsl:call-template name="create-unique-style-id">
-                        <xsl:with-param name="styleName" select="parent::*/@text:style-name"/>
-                        <xsl:with-param name="styleFamily" select="'table'"/>
-                    </xsl:call-template>
+                    <xsl:value-of select="translate(parent::*/@text:style-name, '.,;: %()[]/\+', '_____________')"/>
                 </xsl:attribute>
             </xsl:if>
 
@@ -320,10 +317,7 @@ Scenarios unmatched:
                     <xsl:element namespace="{$namespace}" name="p">
                         <xsl:if test="$position = 1">
                             <xsl:attribute name="class">
-                                <xsl:call-template name="create-unique-style-id">
-                                    <xsl:with-param name="styleName" select="@text:style-name"/>
-                                    <xsl:with-param name="styleFamily" select="'paragraph'"/>
-                                </xsl:call-template>
+                                <xsl:value-of select="translate(@text:style-name, '.,;: %()[]/\+', '_____________')"/>
                             </xsl:attribute>
                         </xsl:if>
                         <xsl:apply-templates mode="content-table">
@@ -347,10 +341,7 @@ Scenarios unmatched:
                                     <xsl:element namespace="{$namespace}" name="p">
                                         <xsl:if test="$position = 1">
                                             <xsl:attribute name="class">
-                                                <xsl:call-template name="create-unique-style-id">
-                                                    <xsl:with-param name="styleName" select="@text:style-name"/>
-                                                    <xsl:with-param name="styleFamily" select="'paragraph'"/>
-                                                </xsl:call-template>
+                                                <xsl:value-of select="translate(@text:style-name, '.,;: %()[]/\+', '_____________')"/>
                                             </xsl:attribute>
                                         </xsl:if>
                                         <xsl:call-template name="grab-cell-content-before-tab-stop">
@@ -367,10 +358,7 @@ Scenarios unmatched:
                                     <xsl:element namespace="{$namespace}" name="p">
                                         <xsl:if test="$position = 1">
                                             <xsl:attribute name="class">
-                                                <xsl:call-template name="create-unique-style-id">
-                                                    <xsl:with-param name="styleName" select="@text:style-name"/>
-                                                    <xsl:with-param name="styleFamily" select="'paragraph'"/>
-                                                </xsl:call-template>
+                                                <xsl:value-of select="translate(@text:style-name, '.,;: %()[]/\+', '_____________')"/>
                                             </xsl:attribute>
                                         </xsl:if>
                                         <xsl:call-template name="grab-cell-content-before-tab-stop">
@@ -394,10 +382,7 @@ Scenarios unmatched:
                                 <xsl:element namespace="{$namespace}" name="p">
                                     <xsl:if test="$position = 1">
                                         <xsl:attribute name="class">
-                                            <xsl:call-template name="create-unique-style-id">
-                                                <xsl:with-param name="styleName" select="@text:style-name"/>
-                                                <xsl:with-param name="styleFamily" select="'paragraph'"/>
-                                            </xsl:call-template>
+                                            <xsl:value-of select="translate(@text:style-name, '.,;: %()[]/\+', '_____________')"/>
                                         </xsl:attribute>
                                     </xsl:if>
                                     <xsl:element namespace="{$namespace}" name="td">

--- a/src/test/resources/odf1.4/tools/odf2html/export/xhtml/body.xsl
+++ b/src/test/resources/odf1.4/tools/odf2html/export/xhtml/body.xsl
@@ -19,7 +19,7 @@
 <!--
     For further documentation and updates visit http://xml.openoffice.org/odf2xhtml
 -->
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xt="http://www.jclark.com/xt" xmlns:common="http://exslt.org/common" xmlns:xalan="http://xml.apache.org/xalan" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" exclude-result-prefixes="chart config dc dom dr3d draw fo form loext math meta number office ooo oooc ooow presentation script style svg table text xforms xlink xsd xsi xt common xalan" xmlns="http://www.w3.org/1999/xhtml">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xt="http://www.jclark.com/xt" xmlns:common="http://exslt.org/common" xmlns:xalan="http://xml.apache.org/xalan" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" exclude-result-prefixes="chart config dc dom dr3d draw fo form loext math meta number office ooo oooc ooow script style svg table text xforms xlink xsd xsi xt common xalan" xmlns="http://www.w3.org/1999/xhtml">
 
 
     <!--+++++ INCLUDED XSL MODULES +++++-->
@@ -141,21 +141,15 @@
             </xsl:choose>
             <!-- adapt page size -->
             <xsl:variable name="pageWidth" select="$pageProperties/style:page-layout-properties/@fo:page-width"/>
-            <xsl:variable name="pageHeight" select="$pageProperties/style:page-layout-properties/@fo:height"/>
 
             <!-- multiple backgroundimages for different page styles (never used in html) -->
             <xsl:variable name="backgroundImage" select="$pageProperties/style:page-layout-properties/style:background-image"/>
             <!-- page margins & background image  -->
-            <xsl:if test="$pageWidth or $pageHeight or $pageProperties/style:page-layout-properties/@fo:* or $backgroundImage/@xlink:href">
+            <xsl:if test="$pageWidth or $pageProperties/style:page-layout-properties/@fo:* or $backgroundImage/@xlink:href">
                 <xsl:attribute name="style">
                     <xsl:if test="$pageWidth">
                         <xsl:text>max-width:</xsl:text>
-                        <xsl:value-of select="$pageWidth" />
-                        <xsl:text>;</xsl:text>
-                    </xsl:if>
-                    <xsl:if test="$pageHeight">
-                        <xsl:text>max-height:</xsl:text>
-                        <xsl:value-of select="$pageHeight" />
+                        <xsl:value-of select="$pageWidth"/>
                         <xsl:text>;</xsl:text>
                     </xsl:if>
                     <xsl:if test="$pageProperties/style:page-layout-properties/@fo:* or $backgroundImage/@xlink:href">
@@ -193,7 +187,6 @@
             </xsl:apply-templates>
 
             <!-- adding MathML polyfill JavaScript for Chromium -
-                MathJax mml-svg.js as retrieved from https://cdn.jsdelivr.net/npm/mathjax@3/es5/mml-svg.js
                 <script type="text/javascript" src="https://oasis-tcs.github.io/odf-tc/odf1.3/styles/mml-svg.js"/> -->
             <xsl:element name="script">
                 <xsl:attribute name="type">text/javascript</xsl:attribute>
@@ -267,20 +260,20 @@
         <xsl:text>&#xa;</xsl:text>
         <xsl:element name="div">
             <xsl:variable name="dimension">
-                <xsl:apply-templates select="@fo:min-width" />
-                <xsl:apply-templates select="@fo:max-width" />
-                <xsl:apply-templates select="@fo:min-height" />
-                <xsl:apply-templates select="@fo:max-height" />
+                <xsl:apply-templates select="@fo:min-width"/>
+                <xsl:apply-templates select="@fo:max-width"/>
+                <xsl:apply-templates select="@fo:min-height"/>
+                <xsl:apply-templates select="@fo:max-height"/>
             </xsl:variable>
-            <xsl:if test="normalize-space($dimension)!=''">
+            <xsl:if test="$dimension">
                 <xsl:attribute name="style">
-                    <xsl:value-of select="$dimension" />
+                    <xsl:value-of select="$dimension"/>
                 </xsl:attribute>
             </xsl:if>
-
-            <xsl:apply-templates select="@xml:id">
-                <xsl:with-param name="globalData" select="$globalData" />
+            <xsl:apply-templates select="@draw:name">
+                <xsl:with-param name="globalData" select="$globalData"/>
             </xsl:apply-templates>
+
             <xsl:apply-templates select="node()">
                 <xsl:with-param name="globalData" select="$globalData"/>
             </xsl:apply-templates>
@@ -379,7 +372,7 @@
                 </xsl:if>
 
             </xsl:when>
-            <xsl:when test="name() = 'draw:frame' and ((normalize-space($childText) != '')  or (((count(*) - count(text:soft-page-break)) &gt; 1)))">
+            <xsl:when test="draw:frame and ((normalize-space($childText) != '')  or (((count(*) - count(text:soft-page-break)) &gt; 1)))">
                 <!-- If there is a 'draw:frame' child with text (not being whitespace alone) and more than the draw:frame alone and
                     not the draw:frame and a soft-page-break alone (which is quite often) -->
 
@@ -435,7 +428,7 @@
                     &#160; is an unbreakable whitespace to give content to the element and force a browser not to ignore the element -->
                 <div style="clear:both; line-height:0; width:0; height:0; margin:0; padding:0;">&#160;</div>
             </xsl:when>
-            <xsl:when test="text:tab and not(ancestor::text:index-body)">                
+            <xsl:when test="text:tab and not(ancestor::text:index-body)">
                 <!-- If there is a tabulator (ie. text:tab) within a paragraph, a heuristic for ODF tabulators creates a
                     span for every text:tab embracing the following text nodes aligning them according to the tabulator.
                     A line break or another text:tab starts a new text:span, line break even the tab counter for the line.
@@ -454,7 +447,7 @@
                             <xsl:variable name="paragraphName" select="@text:style-name" />
                             <xsl:variable name="imageParagraphStyle" select="$globalData/all-styles/style[@style:name = $paragraphName]/final-properties"/>
                             <!-- Only the left margin of the first paragraph of a list item will be added to the margin of the complete list (all levels)-->
-                            <!-- TODO: left-margin in order with bidirectional -->
+<!-- TODO: left-margin in order with bidirectional -->
                             <xsl:choose>
                                 <xsl:when test="contains($imageParagraphStyle, 'margin-left:')">
                                     <xsl:call-template name="convert2cm">
@@ -718,10 +711,7 @@
                 <xsl:otherwise>p</xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
-        <xsl:if test="name() = 'text:p' and $elementName = 'div'">
-            <xsl:comment>Next 'div' was a 'text:p'.</xsl:comment>
-            <xsl:text>&#xa;</xsl:text>
-        </xsl:if>
+
         <xsl:element name="{$elementName}">
             <xsl:choose>
                 <!-- in ODF borders of paragraphs will be merged by default. Merging means the adjacent paragraphs are building a unit,
@@ -821,7 +811,7 @@
         <xsl:text>;</xsl:text>
     </xsl:template>
 
-    <!-- As soon a frame is within a paragraph (text:p) or page:frame, every child element is floating (CSS) and worked out in sequence.
+    <!-- As soon a frame is within a paragraph (text:p) or page:frame, every child element is  floating (CSS) and worked out in sequence.
     Accumulating prior frame width and adding parent's left margin -->
     <!-- Matching all elements and text beyond a paragraph/text:page which are sibling of a draw:frame -->
     <xsl:template match="* | text()" mode="frameFloating">
@@ -831,9 +821,11 @@
         <xsl:param name="leftPosition" select="0" />
         <xsl:param name="parentMarginLeft" />
         <xsl:param name="stopAtFirstFrame" select="false()" />
+        <xsl:param name="tdf146264hack" select="false()" />
 
         <xsl:choose>
             <xsl:when test="name() = 'draw:frame' and not($stopAtFirstFrame)">
+
                 <!-- if the first node is a draw:frame create a div -->
                 <xsl:call-template name="createDrawFrame">
                     <xsl:with-param name="globalData" select="$globalData"/>
@@ -859,9 +851,14 @@
                                 <xsl:value-of select="$leftPosition"/>
                                 <xsl:text>cm;</xsl:text>
                             </xsl:attribute>
-                            <xsl:apply-templates select=".">
-                                <xsl:with-param name="globalData" select="$globalData"/>
-                            </xsl:apply-templates>
+                            <!-- This xsl:if is the meat of the extremely ugly "fix" to tdf#146264. It probably has unintended
+                                 bad side-effects.
+                            -->
+                            <xsl:if test="not($tdf146264hack)">
+                                <xsl:apply-templates select=".">
+                                    <xsl:with-param name="globalData" select="$globalData"/>
+                                </xsl:apply-templates>
+                            </xsl:if>
                             <!-- if it is a frame sibling it will be NOT encapsulated within the div (as already within one) -->
                             <xsl:if test="not($nextSiblingIsFrame)">
                                 <xsl:apply-templates select="following-sibling::node()[1]" mode="frameFloating">
@@ -932,11 +929,13 @@
         <xsl:param name="globalData"/>
         <xsl:param name="previousFrameWidths" select="0"/>
         <xsl:param name="previousFrameHeights" select="0" />
+        <xsl:param name="tdf146264hack" select="false()" />
 
         <xsl:call-template name="createDrawFrame">
             <xsl:with-param name="globalData" select="$globalData" />
             <xsl:with-param name="previousFrameWidths" select="$previousFrameWidths"/>
             <xsl:with-param name="previousFrameHeights" select="$previousFrameHeights"/>
+            <xsl:with-param name="tdf146264hack" select="$tdf146264hack"/>
         </xsl:call-template>
         <!-- after the last draw:frame sibling the CSS float is disabled -->
         <xsl:if test="@text:anchor-type!='as-char'">
@@ -980,6 +979,7 @@
         <xsl:param name="previousFrameHeights" select="0" />
         <xsl:param name="parentMarginLeft"/>
         <xsl:param name="stopAtFirstFrame" select="false()" />
+        <xsl:param name="tdf146264hack" select="false()" />
 
         <xsl:variable name="parentMarginLeftNew">
             <xsl:choose>
@@ -1060,6 +1060,14 @@
             <xsl:with-param name="leftPosition" select="$leftPosition"/>
             <xsl:with-param name="svgY" select="$svgY"/>
         </xsl:call-template>
+        <xsl:apply-templates select="following-sibling::node()[1]" mode="frameFloating">
+            <xsl:with-param name="globalData" select="$globalData"/>
+            <xsl:with-param name="previousFrameWidths" select="$previousFrameWidths + $svgWidth"/>
+            <xsl:with-param name="parentMarginLeft" select="$parentMarginLeftNew"/>
+            <xsl:with-param name="leftPosition" select="$leftPosition"/>
+            <xsl:with-param name="stopAtFirstFrame" select="$stopAtFirstFrame" />
+            <xsl:with-param name="tdf146264hack" select="$tdf146264hack" />
+        </xsl:apply-templates>
     </xsl:template>
 
     <xsl:template name="createDrawFrame2">
@@ -1093,33 +1101,18 @@
                     <xsl:attribute name="style">
                     <xsl:call-template name="widthAndHeight"/>
                     <xsl:text> padding:0; </xsl:text>
-                    <xsl:choose>
-                        <xsl:when test="@text:anchor-type='as-char'">
-                            <!-- images being used as character are not floating and are not positioned (CSS position:static being the default)-->
-                            <!--<xsl:text> position:static;</xsl:text>-->
-                        </xsl:when>
-                        <xsl:when test="@text:anchor-type!='as-char'">
-                            <!-- all images float (CSS float relative) with a left position calculated by svg:x - parentMarginLeft - previousFrameWidths -->
-                            <xsl:text> float:left; position:relative; left:</xsl:text>
-                                    <xsl:value-of select="$leftPosition" />
-                            <xsl:text>cm; </xsl:text>
-                            <!-- if the frame is anchored on a char -->
-                            <xsl:if test="@text:anchor-type='char'">
-                                <xsl:text>top:</xsl:text>
-                                        <xsl:value-of select="$svgY" />
-                                <xsl:text>cm; </xsl:text>
-                            </xsl:if>
-                        </xsl:when>
-                        <!-- if there is no attribute @text:anchor-type -->
-                        <xsl:otherwise>
-                                <xsl:text> position:absolute; left:</xsl:text>
-                                    <xsl:value-of select="$leftPosition" />
-                            <xsl:text>cm; </xsl:text>
+                    <xsl:if test="@text:anchor-type!='as-char'">
+                        <!-- all images float (CSS float relative) with a left position calculated by svg:x - parentMarginLeft - previousFrameWidths -->
+                        <xsl:text> float:left; position:relative; left:</xsl:text>
+                        <xsl:value-of select="$leftPosition"/>
+                        <xsl:text>cm; </xsl:text>
+                        <!-- if the frame is anchored on a char -->
+                        <xsl:if test="@text:anchor-type='char'">
                             <xsl:text>top:</xsl:text>
-                                    <xsl:value-of select="$svgY" />
+                            <xsl:value-of select="$svgY"/>
                             <xsl:text>cm; </xsl:text>
-                        </xsl:otherwise>
-                    </xsl:choose>
+                        </xsl:if>
+                    </xsl:if>
                 </xsl:attribute>
                 <xsl:apply-templates select="@*">
                     <xsl:with-param name="globalData" select="$globalData"/>
@@ -1215,10 +1208,7 @@
             NOTE: Should be handled as CSS style in style header -->
             <xsl:variable name="min-label" select="$globalData/office:styles/text:outline-style/text:outline-level-style[@text:level = current()/@text:outline-level]/*/@text:min-label-width"/>
             <xsl:attribute name="class">
-                <xsl:call-template name="create-unique-style-id">
-                    <xsl:with-param name="styleName" select="@text:style-name"/>
-                    <xsl:with-param name="styleFamily" select="'paragraph'"/>
-                </xsl:call-template>
+                <xsl:value-of select="translate(@text:style-name, '.,;: %()[]/\+', '_____________')"/>
             </xsl:attribute>
 
             <xsl:call-template name="create-heading-anchor">
@@ -2036,8 +2026,7 @@
                                 <xsl:otherwise>
                                     <xsl:variable name="listLabelWidth">
                                         <xsl:choose>
-                                            <!-- only evaluate this attribute if is higher 0 -->
-                                            <xsl:when test="$minLabelWidth &gt; 0">
+                                            <xsl:when test="$minLabelWidth">
                                                 <xsl:value-of select="$minLabelWidth"/>
                                             </xsl:when>
                                             <xsl:otherwise>
@@ -2092,11 +2081,9 @@
                                                     <xsl:apply-templates select="text:number" mode="listnumber"/>
                                                 </xsl:when>
                                                 <xsl:when test="name($listLevelStyle) = 'text:list-level-style-bullet'">
-                                                    <!-- not viewed in LO similar to tdf146264
-                                                    <xsl:value-of select="$listLevelStyle/@style:num-prefix"/>-->
+                                                    <xsl:value-of select="$listLevelStyle/@style:num-prefix"/>
                                                     <xsl:value-of select="$listLevelStyle/@text:bullet-char"/>
-                                                    <!-- not viewed in LO see tdf146264
-                                                    <xsl:value-of select="$listLevelStyle/@style:num-suffix"/>-->
+                                                    <xsl:value-of select="$listLevelStyle/@style:num-suffix"/>
                                                 </xsl:when>
                                                 <xsl:when test="name($listLevelStyle) = 'text:list-level-style-number'">
                                                     <xsl:value-of select="$listLevelStyle/@style:num-prefix"/>
@@ -2602,6 +2589,7 @@
             <xsl:apply-templates>
                 <xsl:with-param name="globalData" select="$globalData"/>
                 <xsl:with-param name="listIndent" select="$minLabelWidth"/>
+                <xsl:with-param name="tdf146264hack" select="true()"/>
             </xsl:apply-templates>
             <!-- this span disables the float necessary to bring two block elements on one line. It contains a space as IE6 bug workaround -->
             <span class="odfLiEnd"></span>
@@ -2859,329 +2847,14 @@
         </xsl:choose>
     </xsl:template>
 
-    <xsl:template match="@text:style-name | @draw:style-name | @draw:text-style-name | @table:style-name | @presentation:style-name">
+    <xsl:template match="@text:style-name | @draw:style-name | @draw:text-style-name | @table:style-name"><!-- | @presentation:style-name-->
         <xsl:param name="globalData"/>
 
-        <!-- the problem there can be more than one style-name attribute! We need to write class once with all style-name attribute values -->
-        <xsl:variable name="classAttributeValue">
-            <xsl:if test="parent::*/@text:style-name != ''"> 
-                <xsl:call-template name="create-unique-style-id">
-                    <xsl:with-param name="styleName" select="parent::*/@text:style-name"/>
-                    <xsl:with-param name="styleFamily">
-                        <xsl:call-template name="get-style-family-name">
-                            <xsl:with-param name="parentName" select="name(..)"/>
-                        </xsl:call-template>
-                    </xsl:with-param>
-                </xsl:call-template><xsl:text> </xsl:text>
-            </xsl:if>        
-            <xsl:if test="parent::*/@draw:style-name != ''"> 
-                <xsl:call-template name="create-unique-style-id">
-                    <xsl:with-param name="styleName" select="parent::*/@draw:style-name"/>
-                    <xsl:with-param name="styleFamily">
-                        <xsl:call-template name="get-style-family-name">
-                            <xsl:with-param name="parentName" select="name(..)"/>
-                        </xsl:call-template>
-                    </xsl:with-param>
-                </xsl:call-template><xsl:text> </xsl:text>
-            </xsl:if>
-            <xsl:if test="parent::*/@draw:text-style-name != ''"> 
-                <xsl:call-template name="create-unique-style-id">
-                    <xsl:with-param name="styleName" select="parent::*/@draw:text-style-name"/>
-                    <xsl:with-param name="styleFamily">
-                        <xsl:call-template name="get-style-family-name">
-                            <xsl:with-param name="parentName" select="name(..)"/>
-                        </xsl:call-template>
-                    </xsl:with-param>
-                </xsl:call-template><xsl:text> </xsl:text>
-            </xsl:if>
-            <xsl:if test="parent::*/@table:style-name != ''"> 
-                <xsl:call-template name="create-unique-style-id">
-                    <xsl:with-param name="styleName" select="parent::*/@table:style-name"/>
-                    <xsl:with-param name="styleFamily">
-                        <xsl:call-template name="get-style-family-name">
-                            <xsl:with-param name="parentName" select="name(..)"/>
-                        </xsl:call-template>
-                    </xsl:with-param>
-                </xsl:call-template><xsl:text> </xsl:text>
-            </xsl:if>
-            <xsl:if test="parent::*/@presentation:style-name != ''"> 
-                <xsl:call-template name="create-unique-style-id">
-                    <xsl:with-param name="styleName" select="parent::*/@presentation:style-name"/>
-                    <xsl:with-param name="styleFamily">
-                        <xsl:call-template name="get-style-family-name">
-                            <xsl:with-param name="parentName" select="name(..)"/>
-                        </xsl:call-template>
-                    </xsl:with-param>
-                </xsl:call-template><xsl:text> </xsl:text>
-            </xsl:if>
-        </xsl:variable>
-
-        <xsl:attribute name="class"><xsl:value-of select="normalize-space($classAttributeValue)"/></xsl:attribute>
+        <xsl:attribute name="class">
+            <xsl:value-of select="translate(., '.,;: %()[]/\+', '_____________')"/>
+        </xsl:attribute>
     </xsl:template>
 
-    
-    <xsl:template name="create-unique-style-id">
-        <xsl:param name="styleName" />
-        <xsl:param name="styleFamily" />
-
-        <xsl:call-template name="abbreviate-style-family-name">
-            <xsl:with-param name="styleFamily" select="$styleFamily"/>
-        </xsl:call-template>
-        <xsl:text>-</xsl:text>
-        <xsl:value-of select="translate($styleName, '.,;: %()[]/\+', '_____________')"/>
-    </xsl:template>
-
-
-    <xsl:template name="abbreviate-style-family-name">
-            <xsl:param name="styleFamily" />
-        <!--<xsl:message>abbreviate-style-family-name: The style family is '<xsl:value-of select="$styleFamily"/>'</xsl:message>-->
-
-        <!-- 
-        	The complete set of family types (aka @style:family) is defined in the ODF specification:
-            	https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part3-schema/OpenDocument-v1.3-os-part3-schema.html#attribute-style_family            
-            (realized style family 'section' is missing, see https://docs.oasis-open.org/office/OpenDocument/v1.3/os/schemas/OpenDocument-v1.3-schema-rng.html#12668 
-                and wrote an issue to ODF TC: https://github.com/oasis-tcs/odf-tc/issues/49
-        -->
-        <xsl:choose>
-            <!-- chart: family name of styles for charts. -->
-            <xsl:when test="$styleFamily='chart'">
-                <xsl:text>chart</xsl:text>
-            </xsl:when>
-            <!-- drawing-page: family name of styles for drawing pages. -->
-            <xsl:when test="$styleFamily='drawing-page'">
-                <xsl:text>page</xsl:text>
-            </xsl:when>
-            <!-- graphic: family name of styles for graphic elements. -->
-            <xsl:when test="$styleFamily='graphic'">
-                <xsl:text>graphic</xsl:text>
-            </xsl:when>
-            <!-- paragraph: family name of styles for paragraphs. -->
-            <xsl:when test="$styleFamily='paragraph'">
-                <xsl:text>paragraph</xsl:text>
-            </xsl:when>
-            <!-- presentation: family name of styles for presentations. -->
-            <xsl:when test="$styleFamily='presentation'">
-                <xsl:text>presentation</xsl:text>
-            </xsl:when>
-            <!-- ruby: family name of styles for ruby text. -->
-            <xsl:when test="$styleFamily='ruby'">
-                <xsl:text>ruby</xsl:text>
-            </xsl:when>
-            <!-- section: family name of styles for sections. -->
-            <xsl:when test="$styleFamily='section'">
-                <xsl:text>section</xsl:text>
-            </xsl:when>            
-            <!-- table: family name of styles for tables. -->
-            <xsl:when test="$styleFamily='table'">
-                <xsl:text>table</xsl:text>
-            </xsl:when>
-            <!-- table-cell: family name of styles for table cells. -->
-            <xsl:when test="$styleFamily='table-cell'">
-                <xsl:text>cell</xsl:text>
-            </xsl:when>
-            <!-- table-column: family name of styles for table columns. -->
-            <xsl:when test="$styleFamily='table-column'">
-                <xsl:text>col</xsl:text>
-            </xsl:when>
-            <!-- table-row: family name of styles for table rows. -->
-            <xsl:when test="$styleFamily='table-row'">
-                <xsl:text>row</xsl:text>
-            </xsl:when>
-            <!-- text: family name of styles for text. -->
-            <xsl:when test="$styleFamily='text'">
-                <xsl:text>text</xsl:text>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:message>WARNING: No style family found for <xsl:value-of select="$styleFamily"/></xsl:message>
-                <xsl:text>unknown-family</xsl:text>
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:template>
-
-    <xsl:template name="get-style-family-name">
-        <xsl:param name="parentName" />
-
-
-        <!--<xsl:message>get-style-family-name: The style parent is '<xsl:value-of select="name(..)"/>'</xsl:message>-->
-        <!--
-        	The complete set of family types (aka @style:family) is defined in the ODF specification:
-            	https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part3-schema/OpenDocument-v1.3-os-part3-schema.html#attribute-style_family
-            (realized style family 'section' is missing, see https://docs.oasis-open.org/office/OpenDocument/v1.3/os/schemas/OpenDocument-v1.3-schema-rng.html#12668
-                and wrote an issue to ODF TC: https://github.com/oasis-tcs/odf-tc/issues/49
-
-            in addition the mapping of styleable ODF elements to their @style:family attribute is available in structured form (XML) in the ODF Toolkit generator project:
-            	https://github.com/tdf/odftoolkit/blob/master/generator/schema2template/src/test/resources/test-input/odf/generation/odfdom-java/dom/grammar-additions.xml#LL43C52-L43C52r-additions.xml#LL43C52-L43C52
-        -->
-        <xsl:choose>
-            <!-- chart: family name of styles for charts. -->
-            <xsl:when test="
-            		$parentName='chart:axis' or
-					$parentName='chart:chart' or
-					$parentName='chart:data-point' or
-					$parentName='chart:error-indicator' or
-					$parentName='chart:floor' or
-					$parentName='chart:footer' or
-					$parentName='chart:grid' or
-					$parentName='chart:legend' or
-					$parentName='chart:mean-value' or
-					$parentName='chart:plot-area' or
-					$parentName='chart:regression-curve' or
-					$parentName='chart:series' or
-					$parentName='chart:stock-gain-marker' or
-					$parentName='chart:stock-loss-marker' or
-					$parentName='chart:stock-range-line' or
-					$parentName='chart:subtitle' or
-					$parentName='chart:title' or
-					$parentName='chart:wall'">
-                <xsl:text>chart</xsl:text>
-            </xsl:when>
-            <!-- drawing-page: family name of styles for drawing pages. -->
-            <xsl:when test="
-            		$parentName='draw:page' or
-            		$parentName='style:handout-master' or
-            		$parentName='style:master-page' or
-        			$parentName='presentation:notes'">
-                <xsl:text>drawing-page</xsl:text>
-            </xsl:when>
-            <!-- graphic: family name of styles for graphic elements. -->
-            <xsl:when test="
-            		$parentName='dr3d:cube' or
-					$parentName='dr3d:extrude' or
-					$parentName='dr3d:rotate' or
-					$parentName='dr3d:scene' or
-					$parentName='dr3d:sphere' or
-					$parentName='draw:caption' or
-					$parentName='draw:circle' or
-					$parentName='draw:connector' or
-					$parentName='draw:control' or
-					$parentName='draw:custom-shape' or
-					$parentName='draw:ellipse' or
-					$parentName='draw:frame' or
-					$parentName='draw:g' or
-					$parentName='draw:line' or
-					$parentName='draw:measure' or
-					$parentName='draw:page-thumbnail' or
-					$parentName='draw:path' or
-					$parentName='draw:polygon' or
-					$parentName='draw:polyline' or
-					$parentName='draw:rect' or
-					$parentName='draw:regular-polygon' or
-					$parentName='office:annotation'">
-                <xsl:text>graphic</xsl:text>
-            </xsl:when>
-            <!-- paragraph: family name of styles for paragraphs. -->
-            <xsl:when test="
-					$parentName='text:alphabetical-index-entry-template' or
-					$parentName='text:bibliography-entry-template' or
-					$parentName='text:h' or
-					$parentName='text:illustration-index-entry-template' or
-					$parentName='text:index-source-style' or
-					$parentName='text:index-title-template' or
-					$parentName='text:object-index-entry-template' or
-					$parentName='text:p' or
-					$parentName='text:table-index-entry-template' or
-					$parentName='text:table-of-content-entry-template' or
-					$parentName='text:user-index-entry-template'">
-                <xsl:text>paragraph</xsl:text>
-            </xsl:when>
-            <!-- presentation: family name of styles for presentations. -->
-            <xsl:when test="
-            		$parentName='dr3d:cube' or
-					$parentName='dr3d:extrude' or
-					$parentName='dr3d:rotate' or
-					$parentName='dr3d:scene' or
-					$parentName='dr3d:sphere' or
-					$parentName='draw:caption' or
-					$parentName='draw:circle' or
-					$parentName='draw:connector' or
-					$parentName='draw:control' or
-					$parentName='draw:custom-shape' or
-					$parentName='draw:ellipse' or
-					$parentName='draw:frame' or
-					$parentName='draw:g' or
-					$parentName='draw:line' or
-					$parentName='draw:measure' or
-					$parentName='draw:page-thumbnail' or
-					$parentName='draw:path' or
-					$parentName='draw:polygon' or
-					$parentName='draw:polyline' or
-					$parentName='draw:rect' or
-					$parentName='draw:regular-polygon' or
-					$parentName='office:annotation'">
-                <xsl:text>presentation</xsl:text>
-            </xsl:when>
-            <!-- ruby: family name of styles for ruby text. -->
-            <xsl:when test="$parentName='text:ruby' or
-            				$parentName='text:ruby-text'">
-                <xsl:text>ruby</xsl:text>
-            </xsl:when>
-            <!-- section: family name of styles for sections. -->
-            <xsl:when test="
-					$parentName='text:alphabetical-index' or
-					$parentName='text:bibliography' or
-					$parentName='text:illustration-index' or
-					$parentName='text:index-title' or
-					$parentName='text:object-index' or
-					$parentName='text:page' or
-					$parentName='text:section' or
-					$parentName='text:s' or
-					$parentName='text:table-index' or
-					$parentName='text:table-of-content' or
-					$parentName='text:user-index'">
-                <xsl:text>section</xsl:text>
-            </xsl:when>
-            <!-- table: family name of styles for tables. -->
-            <xsl:when test="$parentName='table:table'">
-                <xsl:text>table</xsl:text>
-            </xsl:when>
-            <!-- table-cell: family name of styles for table cells. -->
-            <xsl:when test="
-            	$parentName='table:table-cell' or
-				$parentName='table:body' or
-				$parentName='table:even-columns' or
-				$parentName='table:even-rows' or
-				$parentName='table:first-column' or
-				$parentName='table:first-row' or
-				$parentName='table:last-column' or
-				$parentName='table:last-row' or
-				$parentName='table:odd-columns' or
-				$parentName='table:odd-rows' or
-				$parentName='table:covered-table-cell'">
-                <xsl:text>table-cell</xsl:text>
-            </xsl:when>
-            <!-- table-column: family name of styles for table columns. -->
-            <xsl:when test="$parentName='table:table-column'">
-                <xsl:text>table-column</xsl:text>
-            </xsl:when>
-            <!-- table-row: family name of styles for table rows. -->
-            <xsl:when test="$parentName='table:table-row'">
-                <xsl:text>table-row</xsl:text>
-            </xsl:when>
-            <!-- text: family name of styles for text. -->
-            <xsl:when test="
-            	$parentName='text:index-entry-bibliography' or
-				$parentName='text:index-entry-chapter' or
-				$parentName='text:index-entry-link-end' or
-				$parentName='text:index-entry-link-start' or
-				$parentName='text:index-entry-page-number' or
-				$parentName='text:index-entry-span' or
-				$parentName='text:index-entry-tab-stop' or
-				$parentName='text:index-entry-text' or
-				$parentName='text:a' or
-				$parentName='text:span' or
-				$parentName='style:drop-cap' or
-				$parentName='text:line-break' or
-				$parentName='text:tab' or
-				$parentName='text:linenumbering-configuration'">
-                <xsl:text>text</xsl:text>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:message>WARNING: No style family found for parent element <xsl:value-of select="$parentName"/></xsl:message>
-                <xsl:text>unknown-family-parent</xsl:text>
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:template>
-    
 
     <!-- ***************** -->
     <!-- *** Footnotes *** -->

--- a/src/test/resources/odf1.4/tools/odf2html/export/xhtml/header.xsl
+++ b/src/test/resources/odf1.4/tools/odf2html/export/xhtml/header.xsl
@@ -129,12 +129,7 @@
             <xsl:for-each select="$globalData/all-styles/style">
                     <xsl:if test="final-properties != ''">
                         <!-- NOTE: easy process, as only the style family in conjunction with the style name, makes the style unambiguous -->
-                        <xsl:text>.</xsl:text>
-                        <xsl:call-template name="create-unique-style-id">
-                            <xsl:with-param name="styleName" select="@style:name"/>
-                            <xsl:with-param name="styleFamily" select="@style:family"/>
-                        </xsl:call-template>
-                        <xsl:text>{ </xsl:text> <xsl:value-of select="final-properties" /><xsl:text>}
+                        <xsl:text>.</xsl:text><!--<xsl:value-of select="@style:family" /><xsl:text>:</xsl:text>--><xsl:value-of select="translate(@style:name, '.,;: %()[]/\+', '_____________')"/><xsl:text> { </xsl:text> <xsl:value-of select="final-properties" /><xsl:text>}
     </xsl:text>
                     </xsl:if>
 

--- a/src/test/resources/odf1.4/tools/odf2html/export/xhtml/opendoc2xhtml.xsl
+++ b/src/test/resources/odf1.4/tools/odf2html/export/xhtml/opendoc2xhtml.xsl
@@ -145,11 +145,6 @@
     <xsl:template name="start-main">
         <xsl:param name="globalData" />
 
-    <!-- disable style collection debug 
-        <xsl:call-template name="write-collected-styles">
-            <xsl:with-param name="globalData" select="$globalData" />
-        </xsl:call-template> -->
-
         <xsl:variable name="lang">
              <xsl:choose>
                  <xsl:when test="$globalData/meta-file/*/office:meta/dc:language">

--- a/src/test/resources/odf1.4/tools/odf2html/export/xhtml/table.xsl
+++ b/src/test/resources/odf1.4/tools/odf2html/export/xhtml/table.xsl
@@ -206,10 +206,8 @@
 
        <!-- cell style header -->
        <xsl:attribute name="class">
-            <xsl:call-template name="create-unique-style-id">
-                <xsl:with-param name="styleName" select="$styleName"/>
-                <xsl:with-param name="styleFamily" select="'table-cell'"/>
-            </xsl:call-template>
+           <xsl:value-of select="translate($styleName, '.,;: %()[]/\+', '_____________')"/>
        </xsl:attribute>
     </xsl:template>
 </xsl:stylesheet>
+


### PR DESCRIPTION
There is an outstanding PR that isn't finished yet to fix some problems with the current state of the XHTML export.

https://github.com/oasis-tcs/odf-tc/pull/52

Until time is available to finish and integrate this, revert to a known-working (for ODF) revision 0f01b609d59cb4837827caaf010f184e95eb51b7